### PR TITLE
Add startString config parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ In [release-it](https://github.com/release-it/release-it) config at `package.jso
 
 ```json
 {
+  "startString": null,
   "changelogFile": "CHANGELOG.md",
   "changelogDateFormat": "YYYY-MM-DD",
   "changelogTemplate": changelogTemplate,
@@ -34,7 +35,7 @@ In [release-it](https://github.com/release-it/release-it) config at `package.jso
     { "title": "Documentation", "extension": "doc" },
     { "title": "Deprecations and Removals", "extension": "removal" },
     { "title": "Misc", "extension": "misc" }
-  ]
+  ],
 }
 ```
 

--- a/fragments/startString.feature
+++ b/fragments/startString.feature
@@ -1,0 +1,1 @@
+Add startString config parameter.

--- a/src/cli/burn.js
+++ b/src/cli/burn.js
@@ -43,7 +43,11 @@ Remember to create with {green news-fragments create <fragment-type> <fragment-t
     version
   );
 
-  saveChangelogToFile(newsFragmentsUserConfig.changelogFile, renderedTemplate);
+  saveChangelogToFile(
+    newsFragmentsUserConfig.changelogFile,
+    renderedTemplate,
+    newsFragmentsUserConfig.startString
+  );
   deleteFragmentsFiles(newsFragments.fragmentsToDelete);
 
   message = chalk`${newsFragments.fragmentsToBurn.length} fragments burned in ${newsFragmentsUserConfig.changelogFile}`;

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,7 @@ const schema = Joi.object({
   changelogFile: Joi.string().required(),
   changelogDateFormat: Joi.string().required(),
   changelogTemplate: Joi.string().required(),
+  startString: Joi.string(),
   fragmentsFolder: Joi.string().required(),
   fragmentsTypes: Joi.array().items(fragmentsTypesSchema).required(),
 });

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,8 @@ class NewsFragments extends Plugin {
     );
     saveChangelogToFile(
       newsFragmentsUserConfig.changelogFile,
-      renderedTemplate
+      renderedTemplate,
+      newsFragmentsUserConfig.startString
     );
     deleteFragmentsFiles(this.fragmentsToDelete);
   }


### PR DESCRIPTION
This PR adds the possibility to set a `startString` in the `release-it` configuration which will be appended to the changelog:

```js
const startString = `# Changelog

This is an important line which should be preserved after releasing`

const config = {
  plugins: {
    "news-fragments": {
        startString, startString,
      }
  }
}
```

will create the following example changelog:

# Changelog

This is an important line which should be preserved after releasing.

[//]: # (s-2022.14.0)

# [2022.14.0] - 2022-06-08

## Features
* Feature 1
* Feature 2

## Bugfixes
* Bug 1 fixed
* Bug 2 fixed

[//]: # (e-2022.14.0)

⚠️ We have to revert the version-pinning commit which upgraded `marked-terminal` since we still use node `v12.x` in gever-ui and the pinned `marked-terminal` version does no longer support this node version.